### PR TITLE
[Fix] 유사 아티스트 곡 과다 요청 제한 및 툴 출력 개수 통일

### DIFF
--- a/app/agent/tools/artist_tracks.py
+++ b/app/agent/tools/artist_tracks.py
@@ -6,7 +6,7 @@ from app.agent.utils import MusicUtils
 logger = get_logger("app.agent.tools.artist_tracks")
 
 class ArtistTracks:
-    _default_limit = 5
+    _default_limit = 3
 
     @staticmethod
     @tool

--- a/app/agent/tools/country_tracks.py
+++ b/app/agent/tools/country_tracks.py
@@ -6,7 +6,7 @@ from app.agent.utils import MusicUtils
 logger = get_logger("app.agent.tools.country_tracks")
 
 class CountryTracks:
-    _default_limit = 5
+    _default_limit = 3
 
     @staticmethod
     @tool

--- a/app/agent/tools/global_tracks.py
+++ b/app/agent/tools/global_tracks.py
@@ -6,7 +6,7 @@ from app.agent.utils import MusicUtils
 logger = get_logger("app.agent.tools.global_tracks")
 
 class GlobalTracks:
-    _default_limit = 5
+    _default_limit = 3
 
     @staticmethod
     @tool

--- a/app/agent/tools/similar_artists.py
+++ b/app/agent/tools/similar_artists.py
@@ -6,7 +6,7 @@ from app.agent.utils import MusicUtils
 logger = get_logger("app.agent.tools.similar_artists")
 
 class SimilarArtists:
-    _default_limit = 5
+    _default_limit = 1
 
     @staticmethod
     @tool

--- a/app/agent/tools/similar_tracks.py
+++ b/app/agent/tools/similar_tracks.py
@@ -6,7 +6,7 @@ from app.agent.utils import MusicUtils
 logger = get_logger("app.agent.tools.similar_tracks")
 
 class SimilarTracks:
-    _default_limit = 5
+    _default_limit = 3
 
     @staticmethod
     @tool


### PR DESCRIPTION
## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #19

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- 유사 아티스트 곡 과다 요청 제한 및 툴 출력 개수 통일
- 여기에 적어주세요
- 여기에 적어주세요

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] "아이유와 유사한 아티스트의 노래 추천해줘"질문을 날렸을 때 특정 아티스트 한 명의 노래만 추천해주는지 확인
- [ ] 나머지 툴들의 출력 개수 확인

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
### artist_tracks, similar_artists 쪽 툴 확인
- 질문 : "아이유와 유사한 아티스트의 노래를 추천해줘"
- 콘솔 로그 확인
<img width="965" height="354" alt="image" src="https://github.com/user-attachments/assets/203fe481-d9a9-44b8-a184-379d9fb31a7e" />

- Langsmith 확인
<img width="1583" height="629" alt="image" src="https://github.com/user-attachments/assets/493d5908-4afc-4a2b-a301-f22f963fb7de" />


### country_tracks 쪽 툴 확인
- 질문 : "미국에서 인기 있는 노래 추천해줘"
- 콘솔 로그 확인
<img width="960" height="345" alt="image" src="https://github.com/user-attachments/assets/53eeb89c-edac-4f18-bce5-e4103ae804b6" />

- Langsmith 확인
<img width="1580" height="737" alt="image" src="https://github.com/user-attachments/assets/aa636e9d-4434-41eb-82e1-9b9225b954d2" />


### global_tracks 쪽 툴 확인
- 질문 : "전세계에서 인기 있는 노래 추천해줘"
- 콘솔 로그 확인
<img width="961" height="331" alt="image" src="https://github.com/user-attachments/assets/55eb5dbc-d805-4d4c-ae79-0bf5e1e88b6b" />

- Langsmith 확인
<img width="1586" height="727" alt="image" src="https://github.com/user-attachments/assets/fe6c8577-2138-4957-87d8-fabd460e90b7" />


### similar_tracks 쪽 툴 확인
- 질문 : "dancing monkey라는 노래와 유사한 노래 추천해줘"
- 콘솔 로그 확인
<img width="959" height="286" alt="image" src="https://github.com/user-attachments/assets/e3308ae7-5305-4238-9ec6-7d6bad515e6c" />

- Langsmith 확인
<img width="1583" height="701" alt="image" src="https://github.com/user-attachments/assets/73686663-ee33-4554-8f41-a3691e24e2ee" />

